### PR TITLE
Add Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,48 @@ functionality. The following features of the language server are currently suppo
 - [x] Code actions
 - [x] Code completion
 
+## Tasks
+
+This extension additionally provides two [tasks](https://zed.dev/docs/tasks) for running tests. Note that both of the
+tasks assume that the workspace can be read as a bundle (similarly to what the
+[OPA extension for VS Code](https://marketplace.visualstudio.com/items?itemName=tsandall.opa) expects).
+
+### opa test (workspace)
+
+Runs all tests found in the workspace. This is a normal task made available in the command palette (`task: spawn`).
+
+### opa test (single test)
+
+This is a special task (called a _runnable_) which is made available inside of test packages, and
+where a "play" button will appear next to any test rule. Pressing this button will run only that test.
+
+### opa eval ?
+
+The `opa eval` command requires a query containing the full path to what should be evaluated. This is commonly the
+package path + the name of the rule to be evaluated. While we can use a tree-sitter query to extract the rule name —
+like we do for running single tests — we have yet to understand if it's possible / how to extract both the package
+path and the rule name and concatenate them to build a query.
+
+You can however easily create a [custom task](#custom-tasks) for `opa eval` where you provide the query yourself, and
+use that in your project. Such a task may look something like the example below:
+
+**.zed/tasks.json**
+```json
+[
+  {
+    "label": "opa eval (data.policy.main)",
+    "command": "opa",
+    "args": ["eval", "--bundle", "$ZED_WORKTREE_ROOT", "--input", "$ZED_WORKTREE_ROOT/input.json", "data.policy.main"],
+  }
+]
+```
+
+## Custom Tasks
+
+See the Zed documentation [tasks](https://zed.dev/docs/tasks) for information about how to easily add your own custom
+tasks, either globally or to a specific project. These docs also details which environment variables are available in
+the task execution context.
+
 ## Development
 
 To install the extension in development mode, first make sure to have [Rust](https://www.rust-lang.org/tools/install) installed.

--- a/languages/rego/outline.scm
+++ b/languages/rego/outline.scm
@@ -1,0 +1,2 @@
+(rule_head (var) @name
+  (#match? @name "^test_*")) @item

--- a/languages/rego/runnables.scm
+++ b/languages/rego/runnables.scm
@@ -1,0 +1,4 @@
+(
+  (rule_head (var) @run
+    (#match? @run "^test_*"))
+) @rego-test

--- a/languages/rego/tasks.json
+++ b/languages/rego/tasks.json
@@ -1,0 +1,13 @@
+[
+  {
+    "label": "opa test (workspace)",
+    "command": "opa",
+    "args": ["test", "--verbose", "--bundle", "$ZED_WORKTREE_ROOT"]
+  },
+  {
+    "label": "opa test ($ZED_SYMBOL)",
+    "command": "opa",
+    "args": ["test", "--verbose", "--bundle", "--run", "$ZED_SYMBOL", "$ZED_WORKTREE_ROOT"],
+    "tags": ["rego-test"]
+  }
+]


### PR DESCRIPTION
Pretty basic, but it's a start. Particularly interesting is the "runnable" which allows running single tests by clicking the play button in the gutter next to them.

Also provide docs on how users can add their own custom tasks.

Fixes #5