### PR TITLE
ci: build extension and lint rust

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,30 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  markdownlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: npm install -g markdownlint-cli
       - run: markdownlint --config docs/.markdownlint.yaml --ignore docs/CODE_OF_CONDUCT.md README.md docs/
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          components: clippy
+          toolchain: stable
+      - run: cargo +stable clippy -- -D warnings
+  build_extension:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1  
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          # This should be changed to wasm32-wasip2 when available
+          # explanation: https://github.com/zed-industries/zed/blob/main/crates/extension/src/extension_builder.rs#L21-L26
+          targets: wasm32-wasip1
+          toolchain: stable
+      - run: cargo build --target wasm32-wasip1 --release
+  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "my-extension"
+name = "zed-rego"
 version = "0.0.1"
 edition = "2021"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ impl Rego {
         }
 
         zed::set_language_server_installation_status(
-            &language_server_id,
+            language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
 
@@ -61,7 +61,7 @@ impl Rego {
 
         if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
             zed::set_language_server_installation_status(
-                &language_server_id,
+                language_server_id,
                 &zed::LanguageServerInstallationStatus::Downloading,
             );
     


### PR DESCRIPTION
resolve https://github.com/StyraInc/zed-rego/issues/16

Two new actions, one that runs clippy to lint the Rust code and another to build it to a wasi target.

Tested these new actions locally as well with: https://github.com/nektos/act

