### PR TITLE
Update runnables.scm to bring back context-based test tasks

### DIFF
--- a/languages/rego/runnables.scm
+++ b/languages/rego/runnables.scm
@@ -1,4 +1,6 @@
-(
-  (rule_head (var) @run
+((
+  (rule_head (var) @run @test_name
     (#match? @run "^test_*"))
 ) @rego-test
+(#set! tag rego-test)
+)


### PR DESCRIPTION
This functionality broke with a recent Zed release. Now it works again.

Fixes #28

<img width="905" alt="Screenshot 2024-06-24 at 22 51 59" src="https://github.com/StyraInc/zed-rego/assets/510711/a35655f4-c1d9-4260-a2ee-5d117305bfc9">

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/zed-rego/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss this extension in general, please feel free to join
us in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->
