### PR TITLE
fix: resolve linter issue

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.80"
+profile = "minimal"
+components = [ "rustfmt", "clippy" ]
+targets = [ "wasm32-wasip1", "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "wasm32-wasi" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ impl Rego {
             for entry in entries {
                 let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
                 if entry.file_name().to_str() != Some(&version_dir) {
-                    fs::remove_dir_all(&entry.path()).ok();
+                    fs::remove_dir_all(entry.path()).ok();
                 }
             }
         }


### PR DESCRIPTION
Pinned the rust toolchain the same version (1.80) as the zed editor: https://github.com/zed-industries/zed/blob/main/rust-toolchain.toml

I think the github action running clippy should use this pinned version as well because it is set as `dtolnay/rust-toolchain@master`, at least that is what I understood from reading the readme: https://github.com/dtolnay/rust-toolchain/tree/master?tab=readme-ov-file#inputs