### PR TITLE
chore: bump zed_extension_api to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ impl Rego {
         }
 
         if let Some(path) = &self.cached_binary_path {
-            if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
+            if fs::metadata(path).is_ok_and(|stat| stat.is_file()) {
                 return Ok(path.clone());
             }
         }
@@ -59,7 +59,7 @@ impl Rego {
 
         let binary_path = format!("{version_dir}/{asset_name}");
 
-        if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+        if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
             zed::set_language_server_installation_status(
                 language_server_id,
                 &zed::LanguageServerInstallationStatus::Downloading,


### PR DESCRIPTION
no breaking changes, installed extension locally and it built successfully.

Also resolves linter error `this `map_or` is redundant`
